### PR TITLE
Update .gitmodules

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "sockjs-client"]
 	path = src/runtimes/web/dom/sockjs
-	url = git://github.com/pusher/sockjs-client.git
+	url = https://github.com/pusher/sockjs-client.git


### PR DESCRIPTION
Fix npm install error:
fatal: unable to look up github.com (port 9418) 
fatal: clone of 'git://github.com/pusher/sockjs-client.git'
